### PR TITLE
Add nascent ng-bridge =)

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@ We partner with underserved communities and create effective environments for le
           <li><a href="http://railsbridge.org/">RailsBridge</a></li>
           <li><a href="http://www.clojurebridge.org/">ClojureBridge</a></li>
           <li><a href="https://github.com/mobilebridge">MobileBridge</a></li>
+          <li><a href="https://github.com/ng-bridge">ng-bridge</a></li>
           </ul>
 
           <h3>Other Initiatives</h3>


### PR DESCRIPTION
We're starting ng-bridge! 

* https://github.com/ng-bridge
* I gave a talk about Railsbridge's impact on SFRuby, the programming community at large, and on me personally, and asking the Angular community to start: https://www.youtube.com/watch?v=jAjAMAPtZ1I 

I've been calling it ng-bridge, since we have conferences like [ng-conf](http://www.ng-conf.org/) and [ng-europe](http://ngeurope.org/). Would a better official name be AngularBridge, though? All the other bridges are camelcase xD