### PR TITLE
Add a "what we do" page, that isn't currently linked to from anywhere.

### DIFF
--- a/site.css
+++ b/site.css
@@ -11,3 +11,9 @@ body {
 .headline {
   text-align: center;
 }
+
+.toc {
+  background-color: #f8f8f8;
+  border: 1px solid #e7e7e7;
+  border-top: none;
+}

--- a/what-we-do.html
+++ b/what-we-do.html
@@ -1,0 +1,85 @@
+---
+layout: default
+---
+<div class="container">
+  <div class="toc-cont row">
+    <div class="toc col-sm-4">
+      <h1 class="toc-header">What We Do</h1>
+      <ul>
+        <li><a href="#viral">Viral Workshop Model</a></li>
+        <li><a href="#patterns">Patterns for levelling up</a></li>
+        <li><a href="#outreach">Outreach</a></li>
+      </ul>
+    </div>
+  </div>
+  
+  <div class="what-we-do row">
+    <a id="viral"></a>
+    <div>
+      <h2>Viral Workshop Model</h2>
+      <p>
+        The effect on the local SF Ruby Meetup was just one example of the
+        impact of the RailsBridge workshops. Every year, multiple new
+        organizations have started, explicitly borrowing the format, processes,
+        and inspiration, which we call the "viral workshop model."</p>
+      <ol>
+        <li>After creating an open source curriculum and putting on a first event, the rest of the work is match-making existing volunteers and resources.</li>
+        <li>Tapping into the people and the companies in the community, an ongoing sustainable teaching community can be created.</li>
+        <li>Students become TAs become Teachers. The best teachers are those who have learned most recently, and have a passion for giving back to a community that fostered their own development.</li>
+        <li>Companies benefit when we expand the talent pool, and their staff who volunteer at workshops become more expert through teaching and improving their leadership and communication skills.</li>
+      </ol>
+    </div>
+  </div>
+  <div class="patterns row">
+    <a id="patterns"></a>
+    <div class="inner-contents">
+      <h2>Patterns for levelling up</h2>
+      <p>
+        We have many experienced developers who hone their skills through
+        teaching, learning a new language or framework, or contributing to one
+        of our open source projects. For people who are new to coding and want
+        to become software developers, we have few resources after the intro
+        workshops. We believe that we can extend our current model to support
+        someone throughout their journey from novice to expert developer. We
+        already have many success stories of women who came to RailsBridge to
+        learn to code and are now working in the field; however, we still hear
+        of people who aren’t sure what to do after their first or second
+        workshop.</p>
+      <p>
+        The transition from student to teaching assistant to teacher is one
+        effective path, but it is not sufficient. We have experimented with pair
+        programming evenings, mob programming, study groups, co-working days at
+        Internet Cafés and post-workshop hack nights. These are all good and can
+        be effective, but we aspire to create a path (which may be non-linear)
+        that people could follow to become a practicing software developer.</p>
+    </div>
+  </div>
+
+  <div class="outreach row">
+    <a id="outreach"></a>
+    <div class="inner-contents">
+      <h2>Outreach</h2>
+      <p>
+        We believe that if more people know what we were doing, that can create
+        as much positive change as teaching coding and leadership. There are
+        many great untold stories of learning, teaching and transformational
+        change &mdash; with new stories created every month. We would like to
+        do more outreach to participants to invite and support them in telling
+        their stories.</p>
+      <p>
+        We embrace diversity in style -- with a delightful variety of logos and
+        imagery across our many constituent groups. We believe we can create
+        some unifying messaging and branding that could connect our ecosystem
+        of communities. We would like to provide simple common element (widget
+        or footer), which all the groups could embed on their sites. There is
+        also plenty of room to improve the web and social media presence of
+        Bridge Foundry, which could set patterns for the Bridges.</p>
+      <p>
+        If you want to help in any way,
+        <a href="mailto:hello@bridgefoundry.org">let us know</a>.</p>
+    </div>
+  </div>
+
+  <div class="row">
+    <!-- This div, and the div for "container", are intentionally left open so
+         that the content in the footer will line up. -->


### PR DESCRIPTION
Fixes #32.