### PR TITLE
Add virtual office link.

### DIFF
--- a/about.html
+++ b/about.html
@@ -44,7 +44,7 @@ layout: default
           <a name="staff"></a>
           <h2>Staff Members</h2>
           <p>Diana Luepke, COO</p>
-          <p>Mary Jenn, Volunteer Coordinator</p>
+          <p>Mary Jenn, Communications Manager</p>
         </div>
 
 

--- a/about.html
+++ b/about.html
@@ -14,17 +14,20 @@ layout: default
         <p>Bridge Foundry’s primary focus is on expanding diversity in specific technology communities which we call bridges. Each bridge focuses on a specific technology, or set of technologies, and shares open source curriculum and program materials
         with chapters across multiple geographies. Bridge Foundry supplies tools and operational support to the leaders of
         these chapters.</p>
-        
+
         <p>Bridge Foundry’s key differentiator from other tech training initiatives is its focus on training repeat
         participants as teachers. As teachers and leaders, Bridge Foundry volunteers learn to catch and correct disrespectful behavior
         in human interaction, along with gaps in technical understanding. While the focus is on technical skill development,
         we have anecdotal evidence that these skills also contribute to workplace transformation.<p>
-          
+
         <p> All of Bridge Foundry’s bridges
         and chapters focus on expanding diversity in tech via outreach to underrepresented groups. Seventy percent of workshop
         and outreach efforts are targeted primarily at women with the remaining 30% focusing on other underrepresented groups.</p>
 
-        In the US, Bridge Foundry, Inc., is a 501c3 tax-exempt organization. We support many community based initiatives in the US and other countries through grants and open source curricula.
+        In the US, Bridge Foundry, Inc., is a 501c3 tax-exempt organization.
+        For those who want to look under the hood, our official documents (including bylaws, minutes, etc.) are available
+        <a href="https://docs.google.com/document/d/1xyZoOL9GNWIAEXSBoWvaCRSJSFh1qH5QIvsjZFOYwKA/edit?usp=sharing">here.</a>
+        We support many community based initiatives in the US and other countries through grants and open source curricula.
     </div>
   </div>
 
@@ -43,7 +46,7 @@ layout: default
           <p>Diana Luepke, COO</p>
           <p>Mary Jenn, Volunteer Coordinator</p>
         </div>
-        
+
 
         <h2>Program Board</h2>
         <a name="program-board"></a>
@@ -67,20 +70,20 @@ layout: default
 
       </div>
 
-     
-    </div>  
+
+    </div>
 
     <div class="sponsors">
       <a name="sponsors"></a>
       <div class="inner-contents">
         <h2>Sponsors</h2>
         <p class="board__info--sponsor-logo"> <a href="https://balsamiq.com/"><img src="/images/balsamiq-logo.png" width="200px"/></a></p>
-        <p class="board__info--sponsor-logo"><a href="https://www.google.com/"><img src="/images/google-logo.png" width="200px"/></a></p>   
+        <p class="board__info--sponsor-logo"><a href="https://www.google.com/"><img src="/images/google-logo.png" width="200px"/></a></p>
         <p class="board__info--sponsor-logo"><a href="https://dnsimple.com/"><img src="/images/dnsimple-logo.png" width="200px"/></a></p>
         <p class="board__info--sponsor-logo"><a href="https://www.heroku.com/"><img src="/images/heroku-logo.jpg" width="200px"/></a></p>
 
       <p>Please see the <a href="http://www.railsbridge.org/about/sponsors">RailsBridge site</a> for workshop sponsors.</p>
       </div>
-    </div>  
+    </div>
   </div>
-</div>  
+</div>


### PR DESCRIPTION
@ultrasaurus Please make sure you're comfortable both with the language on the page and what we have in the virtual office doc right now to share publicly. I did realized after the transition team conversation that we might not want to have too many of the official docs because it would make it easy for other people/orgs to pose as us, so I'm thinking about removing links to the 501c3 determination and articles of incorporation.