### PR TITLE
Add link to FAQ and info about time and budget

### DIFF
--- a/job-description/finance-manager.md
+++ b/job-description/finance-manager.md
@@ -40,6 +40,12 @@ Bridge Foundry operates without a physical office and you will be able to perfor
 * Familiarity with the tech industry and/or coding
 * Familiarity with diversity & inclusion work
 
+## Time & Budget
+
+We expect this role to require an average of 25-40 hours/month depending on skill, and we have a budget of up to a $1,000/month for the role. We are open to proposals for different ways to structure payment. 
+
 ## To Apply / Learn More
 
-Please send information about your past experience, including your experience working with diverse teams to jobs@bridgefoundry.org. Please ensure that your submission makes it clear that you are operating a business that offers these services and that you are eligible to work as a contractor.
+For more information about the specifics of the role, see our FAQ [here](https://docs.google.com/document/d/1et8YopHgwZ5UkTfWsZpfp7-FvOa-SIZjKsmWBAkdVOM/edit?usp=sharing). 
+
+To express interest, please send information about your past experience, including your experience working with diverse teams to jobs@bridgefoundry.org. Please ensure that your submission makes it clear that you are operating a business that offers these services and that you are eligible to work as a contractor.


### PR DESCRIPTION
In order to increase transparency and help people self-select in terms of whether this falls within their rates.