### PR TITLE
update rustbridge link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,7 +11,7 @@
         <li><a href="http://elixirbridge.org/">ElixirBridge</a></li>
         <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSfoY2hKEEycZtYcNZOvZjFYoZ2Clhwl2_kfaDXkG5HzB0I9fA/viewform">ElmBridge</a></li>
         <li><a href="http://scalabridge.org/">ScalaBridge</a></li>
-        <li><a href="https://github.com/rust-community/rustbridge">RustBridge</a></li>
+        <li><a href="https://rustbridge.com/">RustBridge</a></li>
         </ul>
   </div>
     <div class="col-md-2">


### PR DESCRIPTION
chatted with [@faint_visions](https://twitter.com/@faint_visions] on twitter 
- confirmed we should update this link to https://rustbridge.com/
- also registered rustbridge.org via DNSimple with URL forwarding for now

cc @ashleygwilliams @trentspi 