### PR TITLE
Replace Donate button with a form 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ tags: ready
 
 ## Local development
 
-install Ruby
+Install Ruby and then run:
 
 ```
-gem install bundler
+gem install bundler jekyll
 bundle
 ```
 
@@ -53,10 +53,10 @@ git submodule update --init --recursive
 ```
 
 
-to run the site:
+To run the site:
 
 ```
-jekyll serve
+bundle exec jekyll serve
 ```
 
 point your browser at: http://localhost:4000/

--- a/donate.md
+++ b/donate.md
@@ -2,7 +2,8 @@
 layout: page
 ---
 ## Support Our Work!
-<p>&nbsp;</p>
+
+<br/>
 
 Our mission is to **empower people** with technology <br/>
 through **teaching and facilitating access**,  <br/>
@@ -10,13 +11,11 @@ enlarging the community of people who
 **give back and teach others**.
 
 <br/>
-<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-  <input type="hidden" name="cmd" value="_s-xclick">
-  <input type="hidden" name="hosted_button_id" value="KRSF7C4ZPYFDQ">
-  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-</form>
-<p>&nbsp;</p>
+
+<iframe src="https://interland3.donorperfect.net/weblink/weblink.aspx?name=E351061&id=1" name="donation-form" scrolling="yes" frameborder="0" style="margin: 0 14%;" height="1200px" width="820px" allowfullscreen></iframe>
+
+<br/>
+
 **Your donation is fully tax-deductible.** See [About BridgeFoundry](/about) for more non-profit details, including our EIN.
 
 Contributions to Bridge Foundry allow thousands of volunteers across the world
@@ -29,13 +28,9 @@ Sometimes the only funds that a volunteer organizer needs is $50
 to pay a security guard or $500 for a plane ticket to fly a teacher
 to a new community.
 
-<br/>
-<br/>
-
 ---
 
 You will receive a receipt via email
 after making your donation. If you want a physical receipt or for some reason
 don't receive it, or want to follow-up and hear more about our strategy and
 new initiatives, [contact us](mailto:hello@bridgefoundry.org).
-


### PR DESCRIPTION
This allows us to hook up donations into our donor management system,
minimizing the labor that comes with checking PayPal transactions from
time to time.

Styles are controlled via CSS and the form generator.

See full form [here](https://interland3.donorperfect.net/weblink/weblink.aspx?name=E351061&id=1).

## Before

![Bridge Foundry 2020-02-16 16-31-22](https://user-images.githubusercontent.com/602470/74613152-e77bd880-50d9-11ea-8c23-37c5f7a0403e.png)

## After
The footnote about tax-deductible donations is still there - just not shown in this screenshot.

![Bridge Foundry 2020-02-16 16-34-47](https://user-images.githubusercontent.com/602470/74613217-696c0180-50da-11ea-859d-95aa7a3e0e25.png)
